### PR TITLE
Reduce column length to support utf8mb4

### DIFF
--- a/settings/structure.php
+++ b/settings/structure.php
@@ -48,7 +48,7 @@ $Construct->Table('Page');
 $Construct
     ->PrimaryKey('PageID')
     ->Column('Name', 'varchar(100)', false, 'fulltext')
-    ->Column('UrlCode', 'varchar(255)', false, 'unique')
+    ->Column('UrlCode', 'varchar(100)', false, 'unique')
     ->Column('Body', 'longtext', false, 'fulltext')
     ->Column('Format', 'varchar(20)', true)
     ->Column('DateInserted', 'datetime', false, 'index')


### PR DESCRIPTION
See these issues for more information:
https://github.com/vanilla/vanilla/issues/2082
https://github.com/vanilla/vanilla/pull/2712

Columns that are keys can't be 255 chars long