### PR TITLE
Prevent breaking existing routes

### DIFF
--- a/models/class.pagemodel.php
+++ b/models/class.pagemodel.php
@@ -30,8 +30,8 @@ class PageModel extends Gdn_Model {
     }
 
     /** @var string Route suffixes for expression and target. */
-    public $RouteExpressionSuffix = '(.*)';
-    public $RouteTargetSuffix = '$1';
+    public $RouteExpressionSuffix = '$';
+    public $RouteTargetSuffix = '';
 
     /**
      * Get a set of pages.


### PR DESCRIPTION
Edge case: If a route is the prefix of another route, it will be overwrite the existing route.

Example:
Calling your page "disc" and checking the `Hide "/page" from the URL` option will break all discussion and discussions pages.

$RouteExpressionSuffix could also be rewritten to: `($|/.*)` but since the pagecontroller doesn't take any further arguments it may as well be explicit.