### PR TITLE
Remove PageModel::get()

### DIFF
--- a/models/class.pagemodel.php
+++ b/models/class.pagemodel.php
@@ -34,43 +34,6 @@ class PageModel extends Gdn_Model {
     public $RouteTargetSuffix = '';
 
     /**
-     * Get a set of pages.
-     *
-     * @param int $Offset
-     * @param null $Limit
-     * @param null $Wheres
-     * @return Gdn_DataSet
-     */
-    public function Get($Offset = 0, $Limit = null, $Wheres = null) {
-        $this->SQL->Select('p.*')->From('Page p');
-
-        // Assign up limits and offsets.
-        if ($Limit === null)
-            $Limit = false;
-        else
-            $Limit = is_numeric($Limit) ? $Limit : C('BasicPages.Pages.PerPage', 20);
-
-        $Offset = is_numeric($Offset) ? (($Offset < 0) ? 0 : $Offset) : false;
-
-        if (($Offset !== false) && ($Limit !== false))
-            $this->SQL->Limit($Limit, $Offset);
-
-        // Handle SQL conditions for wheres.
-        $this->EventArguments['Wheres'] = & $Wheres;
-        $this->FireEvent('BeforeGet');
-
-        if (is_array($Wheres))
-            $this->SQL->Where($Wheres);
-
-        // Sort order.
-        $this->SQL->OrderBy('Sort', 'asc');
-
-        $Pages = $this->SQL->Get();
-
-        return $Pages;
-    }
-
-    /**
      * Get data for a single page by ID.
      *
      * @param int $PageID ; Unique ID of page to get.


### PR DESCRIPTION
This causes a PHP notice because of the signature mismatch.
`Gdn_Model::get()` also doesn't take a where array.

Renaming it would also be an option (to keep the events), but `PageModel::get()` is never used with parameters in the entire application, which makes its use identical to Gdn_Model::get().